### PR TITLE
Add Extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ gradlew.bat
 # IntelliJ
 *.ipr
 *.iws
+
+# Other
+*.htgd


### PR DESCRIPTION
Adding the HTGD custom filetype to gitignore to avoid constant merge conflicts.